### PR TITLE
🙋 Change 'display: table' to 'display: table-cell'

### DIFF
--- a/src/Spritesheet.js
+++ b/src/Spritesheet.js
@@ -52,7 +52,7 @@ class Spritesheet extends React.Component {
     let moveStyles = {
       overflow: 'hidden',
       backgroundRepeat: 'no-repeat',
-      display: 'table',
+      display: 'table-cell',
       backgroundImage: 'url(' + this.props.image + ')',
       width: `${this.props.widthFrame}px`,
       height: `${this.props.heightFrame}px`,


### PR DESCRIPTION
First of all, let me thank you for your great component!  🙌🙇‍♀️ 

**Motivation**

`display: table` doesn't accept `height`, since it's a inline display as default.
When using `display: table` for the `react-responsive-spritesheet-container__move`, the div doesn't automatically has a height; so you have to explicitly add it in the  `react-responsive-spritesheet` container.

When using `display: table-cell`, the `react-responsive-spritesheet-container__move` will automatically inherit the height property from its container.