### PR TITLE
Fixed error throwing

### DIFF
--- a/src/Spritesheet.js
+++ b/src/Spritesheet.js
@@ -112,7 +112,7 @@ class Spritesheet extends React.Component {
     };
 
     imgLoadSprite.onerror = () => {
-      console.error(`Failed to load image ${img.src}`)
+      throw new Error(`Failed to load image ${imgLoadSprite.src}`);
     };
   }
 


### PR DESCRIPTION
Now throws an error with the source allowing people to use a normal React Error boundary to catch any errors.